### PR TITLE
fix namespace for temporalElement

### DIFF
--- a/src/main/plugin/iso19115-3/index-fields/common.xsl
+++ b/src/main/plugin/iso19115-3/index-fields/common.xsl
@@ -317,7 +317,7 @@
           <xsl:copy-of select="gn-fn-iso19115-3:index-field('geoDescCode', ., $langId)"/>
         </xsl:for-each>
 
-        <xsl:for-each select="mri:temporalElement/gex:EX_TemporalExtent/gex:extent">
+        <xsl:for-each select="gex:temporalElement/gex:EX_TemporalExtent/gex:extent">
           <xsl:for-each select="gml:TimePeriod">
             <Field name="tempExtentBegin"
                    string="{lower-case(gn-fn-iso19115-3:formatDateTime(gml:beginPosition|gml:begin/gml:TimeInstant/gml:timePosition))}"


### PR DESCRIPTION
The field "tempExtentBegin" of the metadata is not indexed because the namespace of the "temporalElement" is not correct.